### PR TITLE
README & minimal libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(initrfs LANGUAGES C)
+project(initrfs LANGUAGES C ASM)
 
 #########
 # Build #
@@ -9,15 +9,27 @@ project(initrfs LANGUAGES C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 
-include_directories(include)
+execute_process(
+	COMMAND uname -m
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	OUTPUT_VARIABLE CMAKE_SYSTEM_PROCESSOR
+)
 
-file(GLOB_RECURSE MKINITRFS_SOURCES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/src/mkinitrfs/*.c)
+file(GLOB_RECURSE MKINITRFS_SOURCES CONFIGURE_DEPENDS src/mkinitrfs/*.c)
 add_executable(mkinitrfs ${MKINITRFS_SOURCES})
 
-file(GLOB_RECURSE INIT_SOURCES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/src/init/*.c)
+file(GLOB_RECURSE LIBINITCRT_SOURCES CONFIGURE_DEPENDS src/libinitcrt/*.c src/libinitcrt/*.${CMAKE_SYSTEM_PROCESSOR}.s)
+add_library(initcrt ${LIBINITCRT_SOURCES})
+
+file(GLOB_RECURSE INIT_SOURCES CONFIGURE_DEPENDS src/init/*.c)
 add_executable(init ${INIT_SOURCES})
 
-target_link_libraries(init -static)
+target_compile_options(initcrt PRIVATE -nostdinc -ffreestanding)
+target_include_directories(initcrt PUBLIC include)
+target_link_libraries(initcrt -nostdlib -static)
+
+target_compile_options(init PRIVATE -nostdinc -ffreestanding)
+target_link_libraries(init PRIVATE initcrt -nostdlib -static)
 
 ########
 # Test #

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # initrfs
 
-Minimal initramfs
+Minimal initramfs for a simplified boot sequence.
+
+Usual initramfs tend to embed whole shells and utilities inside the filesystem.
+Effectively providing a small operating system. Which is often overkill for a boot sequence.
+To minimize initrd.img size and fasten the boot sequence, this initramfs doesn't embed modules
+and executes a single binary executable. It then leverages the kernel's cmdline arguments to
+mount the root filesystem. Once the root filesystem is mounted, it parses a config.sys file,
+which provides fstab and modules arguments.
+
+## Configure, build and install
+
+CMake is used to configure, build and install binaires and documentations, version 3.14 minimum is required:
+
+```sh
+mkdir -p build && cd build
+cmake ../
+cmake --build .
+cmake --install .
+```
+
+## Tests
+
+There is no real automated test infrastructure yet.
+But you can specify a qemu-system program to verify the validity of the boot sequence.
+Note: mke2fs is used to create the disk image, it is usually located in /sbin, which may not be in your default PATH.
+
+```sh
+mkdir -p build && cd build
+cmake ../
+cmake --build .
+ctest -V
+```
+

--- a/include/_NULL.h
+++ b/include/_NULL.h
@@ -1,0 +1,7 @@
+#ifndef _NULL_H
+#define _NULL_H
+
+#define NULL ((void *)0)
+
+/* _NULL_H */
+#endif

--- a/include/_size_t.h
+++ b/include/_size_t.h
@@ -1,0 +1,7 @@
+#ifndef _SIZE_T_H
+#define _SIZE_T_H
+
+typedef __SIZE_TYPE__ size_t;
+
+/* _SIZE_T_H */
+#endif

--- a/include/_ssize_t.h
+++ b/include/_ssize_t.h
@@ -1,0 +1,7 @@
+#ifndef _SSIZE_T_H
+#define _SSIZE_T_H
+
+typedef long ssize_t;
+
+/* _SSIZE_T_H */
+#endif

--- a/include/_uint8_t.h
+++ b/include/_uint8_t.h
@@ -1,0 +1,9 @@
+#ifndef _UINT8_T_H
+#define _UINT8_T_H
+
+typedef unsigned char uint8_t;
+
+_Static_assert(sizeof(uint8_t) == 1, "uint8_t is not 1 byte!");
+
+/* _UINT8_T_H */
+#endif

--- a/include/ctype.h
+++ b/include/ctype.h
@@ -1,0 +1,8 @@
+#ifndef _CTYPE_H
+#define _CTYPE_H
+
+int isspace(int);
+int isdigit(int);
+
+/* _CTYPE_H */
+#endif

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,0 +1,38 @@
+#ifndef _DIRENT_H
+#define _DIRENT_H
+
+struct _DIR {
+	int _fd;
+};
+
+/* The following is aligned with linux's
+ * struct linux_dirent64, beware size types */
+struct dirent {
+	long d_ino;
+	long d_off;
+	unsigned short d_reclen;
+	unsigned char d_type;
+	char d_name[];
+};
+
+#define DT_UNKNOWN 0
+#define DT_FIFO 1
+#define DT_CHR 2
+#define DT_DIR 4
+#define DT_BLK 6
+#define DT_REG 8
+#define DT_LNK 10
+#define DT_SOCK 12
+#define DT_WHT 14
+
+#define dirfd(dirp) ((dirp)->_fd)
+
+typedef struct _DIR DIR;
+
+DIR *fdopendir(int);
+int closedir(DIR *);
+
+struct dirent *readdir(DIR *);
+
+/* _DIRENT_H */
+#endif

--- a/include/err.h
+++ b/include/err.h
@@ -1,0 +1,13 @@
+#ifndef _ERR_H
+#define _ERR_H
+
+#include <stdnoreturn.h>
+
+void noreturn err(int, const char *, ...);
+void noreturn errx(int, const char *, ...);
+
+void warn(const char *, ...);
+void warnx(const char *, ...);
+
+/* _ERR_H */
+#endif

--- a/include/errno.h
+++ b/include/errno.h
@@ -1,0 +1,46 @@
+#ifndef _ERRNO_H
+#define _ERRNO_H
+
+#define EPERM 1 /* Operation not permitted */
+#define ENOENT 2 /* No such file or directory */
+#define ESRCH 3 /* No such process */
+#define EINTR 4 /* Interrupted system call */
+#define EIO 5 /* I/O error */
+#define ENXIO 6 /* No such device or address */
+#define E2BIG 7 /* Argument list too long */
+#define ENOEXEC 8 /* Exec format error */
+#define EBADF 9 /* Bad file number */
+#define ECHILD 10 /* No child processes */
+#define EAGAIN 11 /* Try again */
+#define ENOMEM 12 /* Out of memory */
+#define EACCES 13 /* Permission denied */
+#define EFAULT 14 /* Bad address */
+#define ENOTBLK 15 /* Block device required */
+#define EBUSY 16 /* Device or resource busy */
+#define EEXIST 17 /* File exists */
+#define EXDEV 18 /* Cross-device link */
+#define ENODEV 19 /* No such device */
+#define ENOTDIR 20 /* Not a directory */
+#define EISDIR 21 /* Is a directory */
+#define EINVAL 22 /* Invalid argument */
+#define ENFILE 23 /* File table overflow */
+#define EMFILE 24 /* Too many open files */
+#define ENOTTY 25 /* Not a typewriter */
+#define ETXTBSY 26 /* Text file busy */
+#define EFBIG 27 /* File too large */
+#define ENOSPC 28 /* No space left on device */
+#define ESPIPE 29 /* Illegal seek */
+#define EROFS 30 /* Read-only file system */
+#define EMLINK 31 /* Too many links */
+#define EPIPE 32 /* Broken pipe */
+#define EDOM 33 /* Math argument out of domain of func */
+#define ERANGE 34 /* Math result not representable */
+
+/* errno should be _Thread_local, however:
+ * - There is no support for those in a static ELFs
+ * - We don't make any use of threads
+ */
+extern int errno;
+
+/* _ERRNO_H */
+#endif

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -1,0 +1,18 @@
+#ifndef _FCNTL_H
+#define _FCNTL_H
+
+#define O_RDONLY 00
+#define O_WRONLY 01
+#define O_RDWR   02
+
+#define AT_FDCWD -100
+
+#define AT_REMOVEDIR 0x200
+
+typedef unsigned int mode_t;
+
+int open(const char *, int, ...);
+int openat(int, const char *, int, ...);
+
+/* _FCNTL_H */
+#endif

--- a/include/stdarg.h
+++ b/include/stdarg.h
@@ -1,0 +1,11 @@
+#ifndef _STDARG_H
+#define _STDARG_H
+
+typedef __builtin_va_list va_list;
+
+#define va_start(ap, parameter) __builtin_va_start(ap, parameter)
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+#define va_end(ap) __builtin_va_end(ap)
+
+/* _STDARG_H */
+#endif

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,0 +1,10 @@
+#ifndef _STDBOOL_H
+#define _STDBOOL_H
+
+#define true  1
+#define false 0
+
+typedef _Bool bool;
+
+/* _STDBOOL_H */
+#endif

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,0 +1,8 @@
+#ifndef _STDDEF_H
+#define _STDDEF_H
+
+#include <_NULL.h>
+#include <_size_t.h>
+
+/* _STDDEF_H */
+#endif

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -1,0 +1,36 @@
+#ifndef _STDIO_H
+#define _STDIO_H
+
+#include <stdarg.h>
+
+#include <_size_t.h>
+#include <_ssize_t.h>
+
+#define stdin _stdin()
+#define stdout _stdout()
+#define stderr _stderr()
+
+#define EOF -1
+
+struct _FILE;
+
+typedef struct _FILE FILE;
+
+FILE *_stdin();
+FILE *_stdout();
+FILE *_stderr();
+
+FILE *fopen(const char *, const char *);
+int fclose(FILE *);
+
+ssize_t getline(char **, size_t *, FILE *);
+ssize_t getdelim(char **, size_t *, int, FILE *);
+
+int fputc(int, FILE *);
+int fputs(const char *, FILE *);
+int puts(const char *);
+
+int vfprintf(FILE *, const char *, va_list);
+
+/* _STDIO_H */
+#endif

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -1,0 +1,21 @@
+#ifndef _STDLIB_H
+#define _STDLIB_H
+
+#include <stdnoreturn.h>
+
+#include <_NULL.h>
+#include <_size_t.h>
+
+#define EXIT_SUCCESS 0
+#define EXIT_FAILURE 1
+
+void *malloc(size_t);
+void *realloc(void *, size_t);
+void free(void *);
+
+void noreturn exit(int);
+
+unsigned long strtoul(const char *, char **, int);
+
+/* _STDLIB_H */
+#endif

--- a/include/stdnoreturn.h
+++ b/include/stdnoreturn.h
@@ -1,0 +1,7 @@
+#ifndef _STDNORETURN_H
+#define _STDNORETURN_H
+
+#define noreturn _Noreturn
+
+/* _STDNORETURN_H */
+#endif

--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,27 @@
+#ifndef _STRING_H
+#define _STRING_H
+
+#include <_NULL.h>
+#include <_size_t.h>
+
+void *memchr(const void *, int, size_t);
+void *memcpy(void *, const void *, size_t);
+void *memmove(void *, const void *, size_t);
+void *memset(void *, int, size_t);
+int memcmp(const void *, const void *, size_t);
+
+char *strchr(const char *, int);
+char *strncpy(char *, const char *, size_t);
+int strncmp(const char *, const char *, size_t);
+int strcmp(const char *, const char *);
+
+size_t strlen(const char *);
+char *strndup(const char *, size_t);
+char *strdup(const char *);
+
+char *strsep(char **, const char *);
+
+char *strerror(int);
+
+/* _STRING_H */
+#endif

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -1,0 +1,17 @@
+#ifndef _SYS_MMAN_H
+#define _SYS_MMAN_H
+
+#define PROT_READ  0x01
+#define PROT_WRITE 0x02
+
+#define MAP_PRIVATE   0x02
+
+#define MAP_ANONYMOUS 0x20
+
+#define MAP_FAILED ((void *)-1)
+
+void *mmap(void *, size_t, int, int, int, long);
+int munmap(void *, size_t);
+
+/* _SYS_MMAN_H */
+#endif

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -1,0 +1,26 @@
+#ifndef _SYS_MOUNT_H
+#define _SYS_MOUNT_H
+
+#define MS_RDONLY 1
+#define MS_NOSUID 2
+#define MS_NODEV 4
+#define MS_NOEXEC 8
+#define MS_SYNCHRONOUS 16
+#define MS_MANDLOCK 64
+#define MS_DIRSYNC 128
+#define MS_NOSYMFOLLOW 256
+#define MS_NOATIME 1024
+#define MS_NODIRATIME 2048
+#define MS_MOVE 8192
+#define MS_SILENT 32768
+#define MS_RELATIME (1 << 21)
+#define MS_I_VERSION (1 << 23)
+#define MS_STRICTATIME (1 << 24)
+#define MS_LAZYTIME (1 << 25)
+
+int mount(const char *, const char *, const char *, unsigned long, const void *);
+int umount(const char *);
+int umount2(const char *, int);
+
+/* _SYS_MOUNT_H */
+#endif

--- a/include/sys/reboot.h
+++ b/include/sys/reboot.h
@@ -1,0 +1,9 @@
+#ifndef _SYS_REBOOT_H
+#define _SYS_REBOOT_H
+
+#define RB_AUTOBOOT 0x1234567
+
+int reboot(int);
+
+/* _SYS_REBOOT_H */
+#endif

--- a/include/time.h
+++ b/include/time.h
@@ -1,0 +1,12 @@
+#ifndef _TIME_H
+#define _TIME_H
+
+struct timespec {
+	long tv_sec;
+	long tv_nsec;
+};
+
+int nanosleep(const struct timespec *, struct timespec *);
+
+/* _TIME_H */
+#endif

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -1,0 +1,26 @@
+#ifndef _UNISTD_H
+#define _UNISTD_H
+
+#include <stdnoreturn.h>
+
+#include <_size_t.h>
+#include <_ssize_t.h>
+
+void noreturn _exit(int);
+
+ssize_t read(int, void *, size_t);
+ssize_t write(int, const void *, size_t);
+int close(int);
+
+int unlinkat(int, const char *, int);
+
+int chdir(const char *);
+int chroot(const char *);
+
+int execv(const char *, char * const []);
+int execve(const char *, char * const [], char * const []);
+
+unsigned int sleep(unsigned int);
+
+/* _UNISTD_H */
+#endif

--- a/src/init/configuration.c
+++ b/src/init/configuration.c
@@ -8,6 +8,7 @@
 #include <sys/mount.h>
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
 #include <err.h>
 
 enum configuration_section {
@@ -93,10 +94,9 @@ configure_section_fstab(char *tab) {
 	desc.flags = mount_resolve_options(options, &data);
 	desc.data = data;
 
-	if(strcmp("/", desc.target) != 0) {
-		if(mount(desc.source, desc.target, desc.fstype, desc.flags, desc.data) != 0) {
-			err(1, "Unable to mount root '%s' (%s) to '%s'", desc.source, desc.fstype, desc.target);
-		}
+	/* EBUSY is sorta trying a remount, which we can just discard at this point. */
+	if(mount(desc.source, desc.target, desc.fstype, desc.flags, desc.data) != 0 && errno != EBUSY) {
+		err(1, "Unable to mount root '%s' (%s) to '%s'", desc.source, desc.fstype, desc.target);
 	}
 
 	free(data);

--- a/src/init/main.c
+++ b/src/init/main.c
@@ -3,6 +3,7 @@
 #include "switchroot.h"
 #include "mountutils.h"
 
+#include <stddef.h>
 #include <stdnoreturn.h>
 #include <unistd.h>
 #include <err.h>

--- a/src/init/mountutils.c
+++ b/src/init/mountutils.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
-#include <linux/mount.h>
 #include <err.h>
 
 struct mount_option {
@@ -168,7 +167,7 @@ mount_resolve_options(const char *options, char **datap) {
 			data = strndup(option + keylen + 1, optionlen - keylen - 1);
 
 			if(data != NULL) {
-				warnx("Mount data option too long '%*s'", (int)optionlen, option);
+				warnx("Mount data option too long '%.*s'", (int)optionlen, option);
 			}
 		}
 	}

--- a/src/init/mountutils.h
+++ b/src/init/mountutils.h
@@ -1,8 +1,6 @@
 #ifndef MOUNTUTILS_H
 #define MOUNTUTILS_H
 
-#include <stddef.h>
-
 struct mount_description {
 	const char *source, *target;
 	const char *fstype, *data;

--- a/src/libinitcrt/crt0.x86_64.s
+++ b/src/libinitcrt/crt0.x86_64.s
@@ -1,0 +1,17 @@
+.section ".note.GNU-stack","",@progbits
+.text
+.extern main, exit
+.global _start, environ
+
+# See System V ABI for more information
+_start:
+	mov (%rsp), %rdi         # Argument count starts at %rsp
+	lea 8(%rsp), %rsi        # Argument pointers start at 8+%rsp
+	lea 8(%rsi,%rdi,8), %rdx # Environment pointers start at 8+8*argc+%rsp
+	mov %rdx, environ
+	call main
+	mov %rax, %rdi
+	call exit
+
+.comm environ, 8
+

--- a/src/libinitcrt/ctype.c
+++ b/src/libinitcrt/ctype.c
@@ -1,0 +1,21 @@
+#include <ctype.h>
+
+int
+isspace(int c) {
+	switch(c) {
+	case ' ':
+	case '\f':
+	case '\n':
+	case '\r':
+	case '\t':
+	case '\v':
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+int
+isdigit(int c) {
+	return c >= '0' && c <= '9';
+}

--- a/src/libinitcrt/dirent.c
+++ b/src/libinitcrt/dirent.c
@@ -1,0 +1,53 @@
+#include <dirent.h>
+
+#include <stdlib.h> /* malloc, free */
+#include <unistd.h> /* close */
+
+#include <_NULL.h>
+#include <_ssize_t.h>
+
+_Static_assert(sizeof(long) == 8, "long is not a 64-bits type");
+
+ssize_t getdents64(int, struct dirent *, unsigned int);
+
+DIR *
+fdopendir(int fd) {
+	DIR * const dirp = malloc(sizeof(*dirp));
+
+	if(dirp != NULL) {
+		dirp->_fd = fd;
+	}
+
+	return dirp;
+}
+
+int
+closedir(DIR *dirp) {
+	const int fd = dirp->_fd;
+
+	free(dirp);
+
+	return close(fd);
+}
+
+struct dirent *
+readdir(DIR *dirp) {
+	static struct dirent *buffer;
+	static size_t capacity;
+
+	if(buffer == NULL) {
+		capacity = 500;
+		buffer = malloc(capacity);
+	}
+
+	struct dirent *entry = buffer;
+	if(entry != NULL) {
+		const ssize_t readval = getdents64(dirp->_fd, entry, capacity);
+
+		if(readval <= 0) {
+			entry = NULL;
+		}
+	}
+
+	return entry;
+}

--- a/src/libinitcrt/err.c
+++ b/src/libinitcrt/err.c
@@ -1,0 +1,57 @@
+#include <err.h>
+
+#include <stdio.h> /* vfprintf */
+#include <stdlib.h> /* exit */
+#include <stdarg.h> /* va_start, va_end */
+#include <string.h> /* strerror */
+#include <errno.h> /* errno */
+
+void noreturn
+err(int eval, const char *format, ...) {
+	va_list ap;
+
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+
+	fputs(": ", stderr);
+	fputs(strerror(errno), stderr);
+	fputc('\n', stderr);
+
+	exit(eval);
+}
+
+void noreturn
+errx(int eval, const char *format, ...) {
+	va_list ap;
+
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+
+	exit(eval);
+}
+
+void
+warn(const char *format, ...) {
+	va_list ap;
+
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+
+	fputs(": ", stderr);
+	fputs(strerror(errno), stderr);
+	fputc('\n', stderr);
+}
+
+void
+warnx(const char *format, ...) {
+	va_list ap;
+
+	va_start(ap, format);
+	vfprintf(stderr, format, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+}

--- a/src/libinitcrt/errno.c
+++ b/src/libinitcrt/errno.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+
+int errno;
+
+long
+_propagate_errno(long returned) {
+	if(returned >= 0) {
+		return returned;
+	} else {
+		errno = -returned;
+		return -1;
+	}
+}

--- a/src/libinitcrt/stdio.c
+++ b/src/libinitcrt/stdio.c
@@ -1,0 +1,290 @@
+#include <stdio.h>
+
+#include <stdlib.h> /* malloc, free */
+#include <string.h> /* strlen */
+#include <unistd.h> /* read, write, close */
+#include <fcntl.h> /* open */
+
+#include <_NULL.h>
+
+struct _FILE {
+	char *_ibuffer;
+	size_t _icount;
+	int _fd;
+};
+
+static int
+_FILE_input_read(FILE *filep) {
+	const size_t size = 500;
+
+	filep->_ibuffer = realloc(filep->_ibuffer, filep->_icount + size);
+	if(filep->_ibuffer != NULL) {
+		char * const begin = filep->_ibuffer + filep->_icount;
+		const ssize_t readval = read(filep->_fd, begin, size);
+
+		if(readval > 0) {
+			filep->_icount += readval;
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+FILE *
+_stdin() {
+	static FILE _file = { ._fd = 0 };
+	return &_file;
+}
+
+FILE *
+_stdout() {
+	static FILE _file = { ._fd = 1 };
+	return &_file;
+}
+
+FILE *
+_stderr() {
+	static FILE _file = { ._fd = 2 };
+	return &_file;
+}
+
+FILE *
+fopen(const char *pathname, const char *mode) {
+	FILE *filep = malloc(sizeof(*filep));
+
+	if(filep != NULL) {
+		/* Runtime only supports file reading, mode is ignored */
+		filep->_ibuffer = NULL;
+		filep->_icount = 0;
+		filep->_fd = open(pathname, O_RDONLY, 0666);
+
+		if(filep->_fd < 0) {
+			free(filep);
+			filep = NULL;
+		}
+	}
+
+	return filep;
+}
+
+int
+fclose(FILE *filep) {
+	const int fd = filep->_fd;
+
+	free(filep);
+
+	return close(fd);
+}
+
+ssize_t
+getline(char **linep, size_t *capacityp, FILE *filep) {
+	return getdelim(linep, capacityp, '\n', filep);
+}
+
+static int
+_strredup(char **destp, size_t *capacityp, const char *src, size_t length) {
+	size_t capacity = *capacityp;
+	char *dest = *destp;
+
+	if(length >= capacity) {
+		capacity = length + 1;
+		dest = realloc(dest, capacity);
+	}
+
+	if(dest != NULL) {
+
+		((unsigned char *)memcpy(dest, src, length))[length] = '\0';
+		*capacityp = capacity;
+		*destp = dest;
+
+		return 0;
+	}
+
+	return -1;
+}
+
+ssize_t
+getdelim(char **linep, size_t *capacityp, int delimiter, FILE *filep) {
+	char *eod; /* End Of Delimition, next character after delimiter if one is there */
+
+	do {
+		/* Look for a delimition, if none found, try to fill more of the input buffer */
+		eod = memchr(filep->_ibuffer, delimiter, filep->_icount);
+	} while(eod == NULL && _FILE_input_read(filep) == 0);
+
+	/* If none is found at this point,
+	 * we reached end of file, delimition is set to remainder of input.
+	 * Else if we are delimited, we set the delimition end past the delimiter. */
+	if(eod == NULL) {
+		eod = filep->_ibuffer + filep->_icount;
+	} else {
+		eod++;
+	}
+
+	/* If the input buffer is empty, we reached end of file,
+	 * whether eod is NULL or not. Else, if eod is not NULL,
+	 * we have at least one delimition to eat. */
+	if(filep->_icount != 0 && eod != NULL) {
+		const size_t length = eod - filep->_ibuffer;
+
+		if(_strredup(linep, capacityp, filep->_ibuffer, length) == 0) {
+			const size_t moved = filep->_icount - length;
+
+			memmove(filep->_ibuffer, eod, moved);
+			filep->_icount = moved;
+
+			return length;
+		}
+	}
+
+	return -1;
+}
+
+int
+fputc(int value, FILE *filep) {
+	const unsigned char character = value;
+
+	if(write(filep->_fd, &character, sizeof(character)) != sizeof(character)) {
+		return EOF;
+	}
+
+	return character;
+}
+
+int
+fputs(const char *string, FILE *filep) {
+	return write(filep->_fd, string, strlen(string));
+}
+
+int
+puts(const char *string) {
+	const size_t length = strlen(string);
+
+	if(write(stdout->_fd, string, length) == length && fputc('\n', stdout) != EOF) {
+		return length + 1;
+	} else {
+		return EOF;
+	}
+}
+
+enum _formatter_state {
+	_FORMATTER_STATE_PRINT,
+	_FORMATTER_STATE_PERCENT,
+	_FORMATTER_STATE_PERCENT_DOT,
+	_FORMATTER_STATE_PERCENT_DOT_STAR,
+	_FORMATTER_STATE_END,
+	_FORMATTER_STATE_ERROR_WRITE,
+	_FORMATTER_STATE_ERROR_UNFINISHED_CONVERSION,
+};
+
+struct _formatter {
+	enum _formatter_state state;
+	unsigned int total;
+	const char *location;
+	const char *tag;
+	int precision;
+	int fd;
+};
+
+static void
+_formatter_print(struct _formatter *formatter, const char *newtag, enum _formatter_state success) {
+	const size_t count = formatter->location - formatter->tag;
+	const ssize_t written = write(formatter->fd, formatter->tag, count);
+
+	if(written == count) {
+		formatter->tag = newtag;
+		formatter->total += count;
+		formatter->state = success;
+	} else {
+		formatter->state = _FORMATTER_STATE_ERROR_WRITE;
+	}
+}
+
+static inline size_t
+_formatter_convert_string_count(const char *string, int precision) {
+	size_t count = strlen(string);
+
+	if(precision > 0 && precision < count) {
+		count = precision;
+	}
+
+	return count;
+}
+
+static void
+_formatter_convert_string(struct _formatter *formatter, const char *string, enum _formatter_state success) {
+
+	if(string == NULL) {
+		string = "(nil)";
+	}
+
+	const size_t count = _formatter_convert_string_count(string, formatter->precision);
+	const ssize_t written = write(formatter->fd, string, count);
+
+	if(written == count) {
+		formatter->tag = formatter->location + 1;
+		formatter->total += count;
+		formatter->state = success;
+	} else {
+		formatter->state = _FORMATTER_STATE_ERROR_WRITE;
+	}
+}
+
+int
+vfprintf(FILE *filep, const char *format, va_list ap) {
+	/* Runtime only supports %s, %.s and %.*s formats */
+	struct _formatter formatter = {
+		.state = _FORMATTER_STATE_PRINT,
+		.total = 0,
+		.location = format,
+		.tag = format,
+		.fd = filep->_fd,
+	};
+
+	while(formatter.state < _FORMATTER_STATE_END) {
+		switch(formatter.state) {
+		case _FORMATTER_STATE_PRINT:
+			switch(*formatter.location) {
+			case '%': _formatter_print(&formatter, formatter.location, _FORMATTER_STATE_PERCENT); break;
+			case '\0': _formatter_print(&formatter, formatter.location, _FORMATTER_STATE_END); break;
+			default: break;
+			}
+			break;
+		case _FORMATTER_STATE_PERCENT:
+			switch(*formatter.location) {
+			case '.':
+				formatter.precision = 0;
+				formatter.state = _FORMATTER_STATE_PERCENT_DOT;
+				break;
+			case 's':
+				formatter.precision = -1;
+				_formatter_convert_string(&formatter, va_arg(ap, const char *), _FORMATTER_STATE_PRINT);
+				break;
+			default: _formatter_print(&formatter, formatter.location + 1, _FORMATTER_STATE_PRINT); break;
+			}
+			break;
+		case _FORMATTER_STATE_PERCENT_DOT:
+			switch(*formatter.location) {
+			case '*':
+				formatter.precision = va_arg(ap, int);
+				formatter.state = _FORMATTER_STATE_PERCENT_DOT_STAR;
+				break;
+			default: formatter.state = _FORMATTER_STATE_ERROR_UNFINISHED_CONVERSION; break;
+			}
+			break;
+		case _FORMATTER_STATE_PERCENT_DOT_STAR:
+			switch(*formatter.location) {
+			case 's': _formatter_convert_string(&formatter, va_arg(ap, const char *), _FORMATTER_STATE_PRINT); break;
+			default: formatter.state = _FORMATTER_STATE_ERROR_UNFINISHED_CONVERSION; break;
+			}
+			break;
+		default:
+			break;
+		}
+		formatter.location++;
+	}
+
+	return formatter.state == _FORMATTER_STATE_END ? formatter.total : -1;
+}
+

--- a/src/libinitcrt/stdlib.c
+++ b/src/libinitcrt/stdlib.c
@@ -1,0 +1,293 @@
+#include <stdlib.h>
+
+#include <ctype.h> /* isdigit */
+#include <string.h> /* memcpy */
+#include <unistd.h> /* _exit */
+#include <sys/mman.h> /* mmap */
+
+#include <_uint8_t.h>
+
+#define _clz(value) _Generic(value, \
+	unsigned int: __builtin_clz, \
+	unsigned long int: __builtin_clzl, \
+	unsigned long long int: __builtin_clzll)(value)
+
+#define MALLOC_OVERHEAD sizeof(size_t)
+
+#define MALLOC_SMALLPOOL_MIN_ORDER 0
+#define MALLOC_MEDIUMPOOL_MIN_ORDER 5
+#define MALLOC_HUGEPOOL_MIN_ORDER 20
+
+#define MALLOC_MEDIUMPOOL_SIZE (MALLOC_HUGEPOOL_MIN_ORDER - MALLOC_MEDIUMPOOL_MIN_ORDER)
+
+struct malloc_arena {
+	void *smallpool;
+	void *mediumpool[MALLOC_MEDIUMPOOL_SIZE];
+
+	size_t smallorder;
+	size_t mediumorder;
+};
+
+static inline void *
+malloc_allocation_mark(size_t *ptr, size_t size) {
+
+	*ptr = size;
+
+	return ptr + 1;
+}
+
+static inline size_t
+malloc_allocation(size_t * restrict ptr, void ** restrict allocation) {
+
+	if(ptr == NULL) {
+		return 0;
+	}
+
+	ptr--;
+	*allocation = ptr;
+
+	return *ptr;
+}
+
+static size_t 
+malloc_smallpool_extend(struct malloc_arena *arena) {
+	const size_t size = 1 << (MALLOC_HUGEPOOL_MIN_ORDER + arena->smallorder);
+	void * const mmaped = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+	if(mmaped != MAP_FAILED) {
+		void **iterator = mmaped, *allocationend = (uint8_t *)mmaped + size;
+
+		while((*iterator = (uint8_t *)iterator + (1 << MALLOC_MEDIUMPOOL_MIN_ORDER)) < allocationend) {
+			iterator = *iterator;
+		}
+
+		*iterator = NULL;
+
+		arena->smallpool = mmaped;
+		arena->smallorder++;
+
+		return size;
+	} else {
+		return 0;
+	}
+}
+
+static void *
+malloc_small(struct malloc_arena *arena, size_t size) {
+	void **allocation;
+
+	if(arena->smallpool == NULL && malloc_smallpool_extend(arena) == 0) {
+		return NULL;
+	}
+
+	allocation = arena->smallpool;
+	arena->smallpool = *allocation;
+
+	return malloc_allocation_mark((size_t *)allocation, size);
+}
+
+static void
+free_small(struct malloc_arena *arena, void **allocation) {
+
+	*allocation = arena->smallpool;
+	arena->smallpool = allocation;
+}
+
+static inline size_t
+malloc_medium_order(size_t value) {
+	return 8 * sizeof(value) - _clz(value) - !(value & (value - 1));
+}
+
+static size_t 
+malloc_mediumpool_extend(struct malloc_arena *arena) {
+	const size_t size = 1 << (MALLOC_HUGEPOOL_MIN_ORDER + arena->mediumorder);
+	void * const mmaped = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+	if(mmaped != MAP_FAILED) {
+		void **iterator = mmaped, *allocationend = (uint8_t *)mmaped + size;
+
+		while((*iterator = (uint8_t *)iterator + (1 << (MALLOC_HUGEPOOL_MIN_ORDER - 1))) < allocationend) {
+			iterator = *iterator;
+		}
+
+		*iterator = NULL;
+
+		arena->mediumpool[MALLOC_MEDIUMPOOL_SIZE - 1] = mmaped;
+		arena->mediumorder++;
+
+		return size;
+	} else {
+		return 0;
+	}
+}
+
+static void *
+malloc_medium(struct malloc_arena *arena, size_t size) {
+	const size_t order = malloc_medium_order(size) - MALLOC_MEDIUMPOOL_MIN_ORDER;
+	size_t index = order;
+	void **allocation;
+
+	while(index < MALLOC_MEDIUMPOOL_SIZE && arena->mediumpool[index] == NULL) {
+		index++;
+	}
+
+	if(index == MALLOC_MEDIUMPOOL_SIZE) {
+
+		if(malloc_mediumpool_extend(arena) == 0) {
+			return NULL;
+		}
+
+		index--;
+	}
+
+	while(index > order) {
+		void **first = arena->mediumpool[index];
+		void **buddy = (void **)((uint8_t *)first + (1 << (index - 1 + MALLOC_MEDIUMPOOL_MIN_ORDER)));
+
+		arena->mediumpool[index] = *first;
+		index--;
+
+		*buddy = arena->mediumpool[index];
+		*first = buddy;
+		arena->mediumpool[index] = first;
+	}
+
+	allocation = arena->mediumpool[index];
+	arena->mediumpool[index] = *allocation;
+
+	return malloc_allocation_mark((size_t *)allocation, size);
+}
+
+static void
+free_medium(struct malloc_arena *arena, void *allocation, size_t size) {
+	size_t index = malloc_medium_order(size) - MALLOC_MEDIUMPOOL_MIN_ORDER;
+	void **ptr = allocation;
+	void **iterator;
+
+	do {
+		const long size = 1 << (index + MALLOC_MEDIUMPOOL_MIN_ORDER);
+		void **lbuddy = (void **)((uint8_t *)ptr - size);
+		void **rbuddy = (void **)((uint8_t *)ptr + size);
+		void **iterator = arena->mediumpool + index;
+
+		while(iterator != NULL && *iterator != lbuddy && *iterator != rbuddy) {
+			iterator = *iterator;
+		}
+
+		if(iterator == NULL) {
+			break;
+		}
+
+		if(*iterator == lbuddy) {
+			*iterator = *lbuddy;
+			ptr = lbuddy;
+		} else { /* *iterator == rbuddy */
+			*iterator = *rbuddy;
+		}
+
+		index++;
+	} while(index < MALLOC_MEDIUMPOOL_SIZE);
+
+	*ptr = arena->mediumpool[index];
+	arena->mediumpool[index] = ptr;
+}
+
+static void *
+malloc_huge(size_t size) {
+	void * const mmaped = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+	if(mmaped != MAP_FAILED) {
+		return malloc_allocation_mark(mmaped, size);
+	} else {
+		return NULL;
+	}
+}
+
+static void
+free_huge(void *allocation, size_t size) {
+	munmap(allocation, size);
+}
+
+static struct malloc_arena arena;
+
+void *
+malloc(size_t size) {
+
+	size += MALLOC_OVERHEAD;
+
+	if(size >= (1 << MALLOC_HUGEPOOL_MIN_ORDER)) {
+		return malloc_huge(size);
+	} else if(size >= (1 << MALLOC_MEDIUMPOOL_MIN_ORDER)) {
+		return malloc_medium(&arena, size);
+	} else if(size > MALLOC_OVERHEAD) {
+		return malloc_small(&arena, size);
+	}
+
+	return NULL;
+}
+
+void *
+realloc(void *ptr, size_t size) {
+
+	if(ptr != NULL) {
+		void *oldallocation;
+		const size_t newsize = size + MALLOC_OVERHEAD;
+		const size_t oldsize = malloc_allocation(ptr, &oldallocation);
+
+		if(newsize <= oldsize) {
+			return ptr;
+		}
+
+		void *newptr = malloc(newsize);
+
+		if(newptr != NULL) {
+			memcpy(newptr, ptr, oldsize - MALLOC_OVERHEAD);
+			free(ptr);
+		}
+
+		return newptr;
+	} else {
+		return malloc(size);
+	}
+}
+
+void
+free(void *ptr) {
+
+	if(ptr != NULL) {
+		void *allocation;
+		const size_t size = malloc_allocation(ptr, &allocation);
+
+		if(size >= (1 << MALLOC_HUGEPOOL_MIN_ORDER)) {
+			free_huge(allocation, size);
+		} else if(size >= (1 << MALLOC_MEDIUMPOOL_MIN_ORDER)) {
+			free_medium(&arena, allocation, size);
+		} else if(size > MALLOC_OVERHEAD) {
+			free_small(&arena, allocation);
+		} /* else error, should we check? */
+	}
+}
+
+void noreturn
+exit(int status) {
+	_exit(status);
+}
+
+unsigned long
+strtoul(const char *string, char **endp, int base) {
+	/* Runtime only supports base 10 */
+	const char *current = string;
+	unsigned long value = 0;
+
+	while(isdigit(*current)) {
+		value = 10 * value + (unsigned long)(*current - '0');
+		current++;
+	}
+
+	if(endp != NULL) {
+		*endp = (void *)current;
+	}
+
+	return value;
+}
+

--- a/src/libinitcrt/string.c
+++ b/src/libinitcrt/string.c
@@ -1,0 +1,243 @@
+#include <string.h>
+
+#include <stdlib.h> /* malloc */
+#include <stdbool.h> /* bool, false */
+#include <_uint8_t.h>
+
+void *
+memchr(const void *pointer, int value, size_t count) {
+	const uint8_t * const end = (const uint8_t *)pointer + count;
+	const uint8_t *current = pointer;
+	const uint8_t byte = value;
+
+	while(current != end && *current != byte) {
+		current++;
+	}
+
+	return current != end ? (void *)current : NULL;
+}
+
+void *
+memcpy(void *destination, const void *source, size_t count) {
+	const uint8_t * const end = (const uint8_t *)source + count;
+	const uint8_t *current = source;
+	uint8_t *buffer = destination;
+
+	while(current != end) {
+		*buffer = *current;
+		current++;
+		buffer++;
+	}
+
+	return destination;
+}
+
+void *
+memmove(void *destination, const void *source, size_t count) {
+	const void * const upper = (const uint8_t *)source + count;
+
+	if(source > destination || (source < destination && upper < destination)) {
+		/* memcpy copies byte by byte from the beginning, this way is safe */
+		memcpy(destination, source, count);
+	} else if(source != destination) {
+		const uint8_t * const end = (const uint8_t *)source - 1;
+		const uint8_t *current = (const uint8_t *)upper - 1;
+		uint8_t *buffer = (uint8_t *)destination + count - 1;
+
+		while(current != end) {
+			*buffer = *current;
+			current--;
+			buffer--;
+		}
+	} /* else source == destination, no copy required */
+
+	return destination;
+}
+
+void *
+memset(void *destination, int value, size_t count) {
+	const uint8_t * const end = (const uint8_t *)destination + count;
+	uint8_t *current = destination;
+	const uint8_t byte = value;
+
+	while(current != end) {
+		*current = byte;
+		current++;
+	}
+
+	return destination;
+}
+
+int
+memcmp(const void *lhs, const void *rhs, size_t count) {
+	const char *left = lhs, *right = rhs;
+	size_t i = 0;
+	int diff;
+
+	while(i != count && !(diff = left[i] - right[i], diff)) {
+		i++;
+	}
+
+	return diff;
+}
+
+char *
+strchr(const char *string, int value) {
+	return memchr(string, value, strlen(string));
+}
+
+char *
+strncpy(char *buffer, const char *string, size_t count) {
+	const size_t length = strlen(string);
+
+	if(length < count) {
+		return memset((uint8_t *)memcpy(buffer, string, length) + length, 0, count - length);
+	} else {
+		return memcpy(buffer, string, count);
+	}
+}
+
+int
+strncmp(const char *lhs, const char *rhs, size_t count) {
+	size_t lhslen = strlen(lhs), rhslen = strlen(rhs);
+
+	if(lhslen < count) {
+		count = lhslen;
+	}
+
+	if(rhslen < count) {
+		count = rhslen;
+	}
+
+	return memcmp(lhs, rhs, count);
+}
+
+int
+strcmp(const char *lhs, const char *rhs) {
+
+	while(*lhs != '\0' && *lhs - *rhs == 0) {
+		lhs++;
+		rhs++;
+	}
+
+	return *lhs - *rhs;
+}
+
+size_t
+strlen(const char *string) {
+	return (const char *)memchr(string, 0, -1) - string;
+}
+
+char *
+strndup(const char *string, size_t count) {
+	const size_t length = strlen(string);
+
+	if(length < count) {
+		count = length;
+	}
+
+	char * const copy = malloc(count + 1);
+
+	if(copy != NULL) {
+		((char *)memcpy(copy, string, count))[count] = '\0';
+	}
+
+	return copy;
+}
+
+char *
+strdup(const char *string) {
+	const size_t length = strlen(string);
+	char * const copy = malloc(length + 1);
+
+	if(copy != NULL) {
+		memcpy(copy, string, length + 1);
+	}
+
+	return copy;
+}
+
+char *
+strsep(char **stringp, const char *delimiters) {
+	char * const string = *stringp;
+
+	if(string != NULL) {
+		const char *delimiter;
+		char *token = string;
+
+		/* Iterating our string for a token */
+		while(*token != '\0') {
+			/* Reset delimiter iterator */
+			delimiter = delimiters;
+
+			/* Is the current character a delimiter? */
+			while(*delimiter != '\0' && *token != *delimiter) {
+				delimiter++;
+			}
+
+			/* If it is, break iteration now */
+			if(*delimiter != '\0') {
+				break;
+			}
+
+			token++;
+		}
+
+		/* Found a delimiter? Mark it, else set next to NULL */
+		if(*token != '\0') {
+			*token = '\0';
+			*stringp = token + 1;
+		} else {
+			*stringp = NULL;
+		}
+	}
+
+	return string;
+}
+
+static char * const errstrings[] = {
+	"Unknown error",
+	"Operation not permitted",
+	"No such file or directory",
+	"No such process",
+	"Interrupted system call",
+	"I/O error",
+	"No such device or address",
+	"Argument list too long",
+	"Exec format error",
+	"Bad file number",
+	"No child processes",
+	"Try again",
+	"Out of memory",
+	"Permission denied",
+	"Bad address",
+	"Block device required",
+	"Device or resource busy",
+	"File exists",
+	"Cross-device link",
+	"No such device",
+	"Not a directory",
+	"Is a directory",
+	"Invalid argument",
+	"File table overflow",
+	"Too many open files",
+	"Not a typewriter",
+	"Text file busy",
+	"File too large",
+	"No space left on device",
+	"Illegal seek",
+	"Read-only file system",
+	"Too many links",
+	"Broken pipe",
+	"Math argument out of domain of func",
+	"Math result not representable",
+};
+
+char *
+strerror(int errcode) {
+	if(errcode < 0 || errcode > sizeof(errstrings) / sizeof(*errstrings)) {
+		errcode = 0;
+	}
+
+	return errstrings[errcode];
+}

--- a/src/libinitcrt/sys/mount.c
+++ b/src/libinitcrt/sys/mount.c
@@ -1,0 +1,6 @@
+#include <sys/mount.h>
+
+int
+umount(const char *target) {
+	return umount2(target, 0);
+}

--- a/src/libinitcrt/syscalls.x86_64.s
+++ b/src/libinitcrt/syscalls.x86_64.s
@@ -1,0 +1,133 @@
+.section ".note.GNU-stack","",@progbits
+.text
+
+/* NOTE: These syscalls shims do the following tasks:
+ * - Translate returned values to errno for all but _exit
+ * - As the SysV ABI third argument is passed through %rcx and not %r10,
+ *   it moves the argument for requiring syscalls (mmap, mount).
+ */
+
+.global read
+read:
+	mov $0, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global write
+write:
+	mov $1, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global open
+open:
+	mov $2, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global close
+close:
+	mov $3, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global mmap
+mmap:
+	mov $9, %rax
+	mov %rcx, %r10
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global munmap
+munmap:
+	mov $11, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global nanosleep
+nanosleep:
+	mov $35, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global execve
+execve:
+	mov $59, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global _exit
+_exit:
+	mov $60, %rax
+	syscall
+
+.global chdir
+chdir:
+	mov $80, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global chroot
+chroot:
+	mov $161, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global mount
+mount:
+	mov $165, %rax
+	mov %rcx, %r10
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global umount2
+umount2:
+	mov $166, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global reboot
+reboot:
+	mov $169, %rax
+	mov %rdi, %rdx
+	mov $0xfee1dead, %rdi
+	mov $672274793, %rsi
+	xor %r10, %r10
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global getdents64
+getdents64:
+	mov $217, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global openat
+openat:
+	mov $257, %rax
+	xor %r10, %r10
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+
+.global unlinkat
+unlinkat:
+	mov $263, %rax
+	syscall
+	mov %rax, %rdi
+	jmp _propagate_errno
+

--- a/src/libinitcrt/unistd.c
+++ b/src/libinitcrt/unistd.c
@@ -1,0 +1,21 @@
+#include <unistd.h>
+
+#include <time.h> /* nanosleep */
+
+extern char **environ;
+
+int
+execv(const char *pathname, char * const argv[]) {
+	return execve(pathname, argv, environ);
+}
+
+unsigned int
+sleep(unsigned int seconds) {
+	struct timespec rqt = { .tv_sec = seconds }, rmt;
+
+	if(nanosleep(&rqt, &rmt) != 0) {
+		return rmt.tv_sec;
+	}
+
+	return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set(TEST_BZIMAGE "/vmlinuz" CACHE STRING "Linux kernel image used to run tests.")
-set(TEST_QEMU_SYSTEM "qemu-system" CACHE STRING "QEMU system emulator to run tests.")
+set(TEST_QEMU_SYSTEM "qemu-system-${CMAKE_SYSTEM_PROCESSOR}" CACHE STRING "QEMU system emulator to run tests.")
 set(TEST_QEMU_OPTIONS "" CACHE STRING "QEMU system emulator additional options.")
 
 add_custom_target(test-initrd ALL DEPENDS initrd.img)
@@ -13,13 +13,14 @@ add_custom_command(
 add_custom_target(test-disk ALL DEPENDS disk.img)
 add_custom_command(
 	OUTPUT disk.img
-	COMMAND mke2fs -q -t ext4 -d rootfs disk.img 5M
+	COMMAND mke2fs -q -I 256 -t ext4 -d rootfs disk.img 5M
 	DEPENDS test-init
 )
 
 add_executable(test-init support/test-init/main.c)
 set_target_properties(test-init PROPERTIES OUTPUT_NAME rootfs/sbin/init)
-target_link_libraries(test-init -static)
+target_compile_options(test-init PRIVATE -nostdinc -ffreestanding)
+target_link_libraries(test-init PRIVATE initcrt -nostdlib -static)
 add_dependencies(test-init test-rootfs)
 
 add_custom_target(test-rootfs DEPENDS rootfs)
@@ -29,5 +30,5 @@ add_custom_command(
 	COMMAND mkdir -p rootfs/sbin rootfs/dev rootfs/proc rootfs/sys
 )
 
-add_test(NAME boot COMMAND ${TEST_QEMU_SYSTEM} ${TEST_QEMU_OPTIONS} -no-reboot -serial stdio -append "panic=-1 console=ttyS0 root=/dev/sda rootfstype=ext4" -kernel ${TEST_BZIMAGE} -initrd initrd.img -drive format=raw,file=disk.img)
+add_test(NAME boot COMMAND ${TEST_QEMU_SYSTEM} ${TEST_QEMU_OPTIONS} -no-reboot -serial stdio -append "panic=-1 console=ttyS0 root=/dev/sda rootfstype=ext4 rootflags=rw,relatime,data=ordered" -kernel ${TEST_BZIMAGE} -initrd initrd.img -drive format=raw,file=disk.img)
 

--- a/test/support/test-init/main.c
+++ b/test/support/test-init/main.c
@@ -9,10 +9,7 @@ main(void) {
 
 	puts("Hello, world!");
 
-	if(reboot(RB_AUTOBOOT) == -1) {
-		err(EXIT_FAILURE, "reboot");
-	}
-
-	/* Never reached */
+	reboot(RB_AUTOBOOT);
+	err(EXIT_FAILURE, "reboot");
 }
 

--- a/test/support/test-rootfs/boot/config.sys
+++ b/test/support/test-rootfs/boot/config.sys
@@ -1,5 +1,5 @@
 [fstab]
-/dev/sda / ext4 rw,relatime,data=ordered 0 1
 none /dev devtmpfs defaults
 none /proc proc defaults
 none /sys sysfs defaults
+/dev/sda / ext4 rw,relatime,data=ordered 0 1


### PR DESCRIPTION
Added README support and the minimal libc to run initrfs and the test init.
The minimal libc supports read buffering for input IO, output is always unbuffered.
The memory allocator is a simple buddy allocator, small but enough for the intended purpose.
Syscalls and crt0 are implemented in assembly stubs, support for x86_64 only for now.